### PR TITLE
Magic get is in Nette 2.4 deprecated. Changing to getter.

### DIFF
--- a/src/JsonPrettyResponse.php
+++ b/src/JsonPrettyResponse.php
@@ -21,10 +21,10 @@ class JsonPrettyResponse extends Nette\Application\Responses\JsonResponse
 	 */
 	public function send(Nette\Http\IRequest $httpRequest, Nette\Http\IResponse $httpResponse)
 	{
-		$httpResponse->setContentType($this->contentType, 'utf-8');
+		$httpResponse->setContentType($this->getContentType(), 'utf-8');
 		$httpResponse->setExpiration(FALSE);
 
-		echo Nette\Utils\Json::encode($this->payload, Nette\Utils\Json::PRETTY);
+		echo Nette\Utils\Json::encode($this->getPayload(), Nette\Utils\Json::PRETTY);
 	}
 
 }


### PR DESCRIPTION
In Nette 2.4 is magic get deprecated. Changed it to getter.
