### PR TITLE
Correctly escape quotes

### DIFF
--- a/src/CSVResponse.php
+++ b/src/CSVResponse.php
@@ -129,6 +129,11 @@ class CSVResponse extends Nette\Object implements Nette\Application\IResponse
 		$delimiter = '"' . $this->delimiter . '"';
 
 		foreach ($this->data as $row) {
+
+                        $row = array_map(function($value) { 
+                            return str_replace('"', '""', $value);
+                        }, $row);
+
 			if (strtolower($this->output_encoding) == 'utf-8') {
 				echo('"' . implode($delimiter, (array) $row) . '"');
 			} else {


### PR DESCRIPTION
If fields contained quotes, they did not get escaped correctly (they were not escaped at all). CSV format requires the quotes to be doubled in that case.